### PR TITLE
Add Okta PKCE Flow environment variable

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -35,6 +35,8 @@ SOLAR_SECRET=#<FILL IN>
 #SOLAR_SSO_OKTA_IDENTITY_PROVIDER_ID=#<FILL IN>
 #SOLAR_SSO_OKTA_AUTHORIZATION_SERVER_ID=#<FILL IN>
 #SOLAR_SSO_OKTA_GROUP_FILTER_REGEX=#<FILL IN>
+# Enables the Authorization Code flow with PKCE. Defaults to false, which uses the Implicit (hybrid) flow
+#SOLAR_SSO_OKTA_USE_PKCE=true
 
 # Azure SSO
 #SOLAR_SSO_AZURE_CLIENT_ID=#<FILL IN>


### PR DESCRIPTION
Add the `SOLAR_SSO_OKTA_USE_PKCE` environmnet variable for configuring Okta to use PKCE/Authorization Code flow