### PR TITLE
Add runtime analytics env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ SOLAR_LICENSE= #<FILL IN>
 ```bash
 
 Everything else is optional. Reach out to support@tonic.ai with any questions.
+
+## Analytics
+
+Release images do not include Amplitude credentials. To enable analytics, set
+`AMPLITUDE_API_KEY` and `ANALYTIC_BACKEND_SALT` in `.env`.
+
+Docker Compose passes these values to the `textual-api` and `textual-worker`
+containers. They are intentionally not passed to ML, Roberta, ASR, log shipper,
+database, or setup helper containers.

--- a/docker-compose-with-gpus.yml
+++ b/docker-compose-with-gpus.yml
@@ -71,6 +71,8 @@ services:
       - "./log-config:/usr/bin/textual/vector_config:Z"
       - "./custom-models:/usr/bin/textual/custom_models:Z"
     environment:
+      AMPLITUDE_API_KEY: ""
+      ANALYTIC_BACKEND_SALT: ""
       SUPERVISOR_CONF: /etc/supervisor/conf.d/supervisord_api.conf
     env_file:
       - .env
@@ -92,6 +94,9 @@ services:
       - "./local-logs:/usr/bin/textual/logs:Z"
       - "./log-config:/usr/bin/textual/vector_config:Z"
       - "./custom-models:/usr/bin/textual/custom_models:Z"
+    environment:
+      AMPLITUDE_API_KEY: ""
+      ANALYTIC_BACKEND_SALT: ""
     env_file:
       - .env
     ports:
@@ -105,6 +110,9 @@ services:
   #   image: quay.io/tonicai/textual-asr:${SOLAR_VERSION}
   #   container_name: textual-asr
   #   restart: unless-stopped
+  #   environment:
+  #     AMPLITUDE_API_KEY: ""
+  #     ANALYTIC_BACKEND_SALT: ""
   #   volumes:
   #     - "./shared-logs:/usr/bin/textual/logs_public:Z"
   #     - "./local-logs:/usr/bin/textual/logs:Z"
@@ -130,6 +138,8 @@ services:
     env_file:
       - .env
     environment:
+      AMPLITUDE_API_KEY: ""
+      ANALYTIC_BACKEND_SALT: ""
       LOG_COLLECTION_FOLDER: "/usr/bin/textual/logs_public"
   # otherwise volumes are owned by root and we cannot use them
   file-perms:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,9 @@ services:
     image: quay.io/tonicai/textual-ml:${SOLAR_VERSION}
     container_name: textual-ml
     restart: unless-stopped
+    environment:
+      AMPLITUDE_API_KEY: ""
+      ANALYTIC_BACKEND_SALT: ""
     volumes:
       - "./shared-logs:/usr/bin/textual/logs_public:Z"
       - "./local-logs:/usr/bin/textual/logs:Z"
@@ -78,6 +81,9 @@ services:
     image: quay.io/tonicai/textual-roberta:${SOLAR_VERSION}
     container_name: textual-roberta
     restart: unless-stopped
+    environment:
+      AMPLITUDE_API_KEY: ""
+      ANALYTIC_BACKEND_SALT: ""
     volumes:
       - "./shared-logs:/usr/bin/textual/logs_public:Z"
       - "./local-logs:/usr/bin/textual/logs:Z"
@@ -96,6 +102,9 @@ services:
   #   image: quay.io/tonicai/textual-asr:${SOLAR_VERSION}
   #   container_name: textual-asr
   #   restart: unless-stopped
+  #   environment:
+  #     AMPLITUDE_API_KEY: ""
+  #     ANALYTIC_BACKEND_SALT: ""
   #   volumes:
   #     - "./shared-logs:/usr/bin/textual/logs_public:Z"
   #     - "./local-logs:/usr/bin/textual/logs:Z"
@@ -121,6 +130,8 @@ services:
     env_file:
       - .env
     environment:
+      AMPLITUDE_API_KEY: ""
+      ANALYTIC_BACKEND_SALT: ""
       LOG_COLLECTION_FOLDER: "/usr/bin/textual/logs_public"
   # otherwise volumes are owned by root and we cannot use them
   file-perms:

--- a/sample.env
+++ b/sample.env
@@ -14,6 +14,12 @@ SOLAR_ADMINISTRATORS=#<FILL IN>
 # Secret used for encryption.  Any string value is valid.
 SOLAR_SECRET=#<FILL IN>
 
+# Analytics
+# Optional. Set these when this deployment should send Amplitude events.
+# Docker Compose passes these values to textual-api and textual-worker.
+#AMPLITUDE_API_KEY=#<FILL IN>
+#ANALYTIC_BACKEND_SALT=#<FILL IN>
+
 # OCR
 # Only necessary if you plan on scanning PDFs.  Note this uses your own Azure account to run OCR on PDFS via Azure Cognitive Services.
 # If you wish to use AWS or GCP services instead, please reach out to your Tonic account rep or support@tonic.ai


### PR DESCRIPTION
## Summary
- document the runtime Amplitude API key and analytics salt settings for Docker Compose installs
- keep analytics env values scoped to textual-api and textual-worker
- explicitly blank those env values on ML, Roberta, ASR, and log-shipper services when they inherit .env

## Verification
- yq '.' docker-compose.yml >/dev/null
- yq '.' docker-compose-with-gpus.yml >/dev/null

Related Solar PR: https://github.com/TonicAI/solar/pull/3023